### PR TITLE
Update screenshots

### DIFF
--- a/dev.bsnes.bsnes.metainfo.xml
+++ b/dev.bsnes.bsnes.metainfo.xml
@@ -56,7 +56,13 @@
   <launchable type="desktop-id">dev.bsnes.bsnes.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://bsnes.dev/images/preview.png</image>
+      <image>https://raw.githubusercontent.com/bsnes-emu/bsnes/master/.assets/tengai-makyou-zero.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/bsnes-emu/bsnes/master/.assets/bahamut-lagoon.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/bsnes-emu/bsnes/master/.assets/user-interface.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://bsnes.dev</url>


### PR DESCRIPTION
Use screenshots stored as assets on the upstream GitHub repository instead of the homepage. The latter recently suffered an outage, which prevented successful completion of subsequent builds.