### PR TITLE
Allow access to /run/media/mmcblk0p1 (the steam deck SD card) by default

### DIFF
--- a/dev.bsnes.bsnes.yaml
+++ b/dev.bsnes.bsnes.yaml
@@ -11,8 +11,9 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --device=all
-  - --filesystem=home:ro
-  - --filesystem=/run/media/mmcblk0p1
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/run/media
 modules:
   - name: bsnes
     buildsystem: simple

--- a/dev.bsnes.bsnes.yaml
+++ b/dev.bsnes.bsnes.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --device=all
   - --filesystem=home:ro
+  - --filesystem=/run/media:ro
 modules:
   - name: bsnes
     buildsystem: simple

--- a/dev.bsnes.bsnes.yaml
+++ b/dev.bsnes.bsnes.yaml
@@ -12,7 +12,7 @@ finish-args:
   - --socket=x11
   - --device=all
   - --filesystem=home:ro
-  - --filesystem=/run/media:ro
+  - --filesystem=/run/media/mmcblk0p1
 modules:
   - name: bsnes
     buildsystem: simple


### PR DESCRIPTION
Added access to `/run/media` by default, so users who aren't familiar with flatpak aren't confused if they can't find ROMs they're storing on an external drive.

My main interest is making sure that the steam deck's SD card can be read by default, since I've seen someone confused that they couldn't find their ROMs on that. So this could be reduced down to `/run/media/mmcblk0p1:ro` if that's preferable.